### PR TITLE
feat: add Windows x86_64 build support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -154,7 +154,7 @@ jobs:
           msystem: MINGW64
           update: true
           install: >-
-            base-devel git nasm yasm cmake ninja
+            base-devel git nasm yasm cmake ninja zip
             mingw-w64-x86_64-toolchain mingw-w64-x86_64-pkgconf
             mingw-w64-x86_64-x264 mingw-w64-x86_64-x265
             mingw-w64-x86_64-aom mingw-w64-x86_64-opus mingw-w64-x86_64-libvpx
@@ -174,8 +174,8 @@ jobs:
 
       - name: Build FFmpeg (Windows)
         if: runner.os == 'Windows'
-        shell: pwsh
-        run: ./scripts/build-ffmpeg.ps1
+        shell: msys2 {0}
+        run: ./scripts/build-ffmpeg-windows.sh
 
       - name: Sign binaries (macOS)
         if: runner.os == 'macOS' && env.APPLE_CERTIFICATE != ''
@@ -194,8 +194,8 @@ jobs:
 
       - name: Package artifacts (Windows)
         if: runner.os == 'Windows'
-        shell: pwsh
-        run: ./scripts/package.ps1
+        shell: msys2 {0}
+        run: ./scripts/package-windows.sh
 
       - name: Notarize (macOS)
         if: runner.os == 'macOS' && env.APPLE_CERTIFICATE != ''

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -141,8 +141,15 @@ jobs:
 
       - name: Bootstrap toolchain (Windows)
         if: runner.os == 'Windows'
-        shell: pwsh
-        run: ./scripts/bootstrap-windows.ps1
+        uses: msys2/setup-msys2@v2
+        with:
+          msystem: MINGW64
+          update: true
+          install: >-
+            base-devel git nasm yasm cmake ninja
+            mingw-w64-x86_64-toolchain mingw-w64-x86_64-pkgconf
+            mingw-w64-x86_64-x264 mingw-w64-x86_64-x265
+            mingw-w64-x86_64-aom mingw-w64-x86_64-opus mingw-w64-x86_64-libvpx
 
       - name: Build FFmpeg (Linux/macOS)
         if: runner.os != 'Windows'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,12 +47,21 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
+      ffmpeg_version: ${{ steps.set-matrix.outputs.ffmpeg_version }}
     steps:
+      - uses: actions/checkout@v4
       - id: set-matrix
         shell: bash
         run: |
           # On tag push, build all platforms. On workflow_dispatch, use the selected inputs.
           BUILD_ALL=${{ github.event_name != 'workflow_dispatch' }}
+
+          # Resolve FFmpeg version from input or profile
+          FFMPEG_VERSION="${{ inputs.ffmpeg_version }}"
+          if [[ -z "$FFMPEG_VERSION" ]]; then
+            FFMPEG_VERSION=$(yq '.ffmpeg.version' profiles/default.yml)
+          fi
+          echo "ffmpeg_version=$FFMPEG_VERSION" >> $GITHUB_OUTPUT
 
           ENTRIES='[]'
           add() { ENTRIES=$(echo "$ENTRIES" | jq -c --argjson e "$1" '. + [$e]'); }
@@ -85,8 +94,7 @@ jobs:
       # Use workflow_dispatch inputs when present, otherwise fall back to defaults
       PROFILE: >-
         ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.profile || 'profiles/default.yml' }}
-      FFMPEG_VERSION: >-
-        ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.ffmpeg_version || '' }}
+      FFMPEG_VERSION: ${{ needs.setup.outputs.ffmpeg_version }}
       ENABLE_NONFREE: >-
         ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.nonfree || false }}
       CCACHE_DIR: ${{ github.workspace }}/.ccache

--- a/scripts/bootstrap-windows.ps1
+++ b/scripts/bootstrap-windows.ps1
@@ -1,5 +1,7 @@
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
-choco install -y msys2
+
+winget install --id MSYS2.MSYS2 -e --source winget
+
 # Install toolchain + deps inside MSYS2
-& C:\tools\msys64\usr\bin\bash -lc "pacman -Sy --noconfirm --needed base-devel git nasm yasm cmake ninja mingw-w64-x86_64-toolchain mingw-w64-x86_64-pkgconf"
+& C:\msys64\usr\bin\bash -lc "pacman -Sy --noconfirm --needed base-devel git nasm yasm cmake ninja mingw-w64-x86_64-toolchain mingw-w64-x86_64-pkgconf"

--- a/scripts/bootstrap-windows.ps1
+++ b/scripts/bootstrap-windows.ps1
@@ -1,7 +1,9 @@
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
-winget install --id MSYS2.MSYS2 -e --source winget
+if (-not (Test-Path "C:\msys64\usr\bin\bash.exe")) {
+  throw "MSYS2 not found. Install it from https://www.msys2.org and ensure it is at C:\msys64."
+}
 
-# Install toolchain + deps inside MSYS2
-& "$env:USERPROFILE\scoop\apps\msys2\current\usr\bin\bash" -lc "pacman -Sy --noconfirm --needed base-devel git nasm yasm cmake ninja mingw-w64-x86_64-toolchain mingw-w64-x86_64-pkgconf"
+$env:MSYSTEM = "MINGW64"
+& "C:\msys64\usr\bin\bash.exe" -lc "pacman -Sy --noconfirm --needed base-devel git nasm yasm cmake ninja mingw-w64-x86_64-toolchain mingw-w64-x86_64-pkgconf mingw-w64-x86_64-x264 mingw-w64-x86_64-x265 mingw-w64-x86_64-aom mingw-w64-x86_64-opus mingw-w64-x86_64-libvpx"

--- a/scripts/bootstrap-windows.ps1
+++ b/scripts/bootstrap-windows.ps1
@@ -4,4 +4,4 @@ $ErrorActionPreference = 'Stop'
 winget install --id MSYS2.MSYS2 -e --source winget
 
 # Install toolchain + deps inside MSYS2
-& C:\msys64\usr\bin\bash -lc "pacman -Sy --noconfirm --needed base-devel git nasm yasm cmake ninja mingw-w64-x86_64-toolchain mingw-w64-x86_64-pkgconf"
+& "$env:USERPROFILE\scoop\apps\msys2\current\usr\bin\bash" -lc "pacman -Sy --noconfirm --needed base-devel git nasm yasm cmake ninja mingw-w64-x86_64-toolchain mingw-w64-x86_64-pkgconf"

--- a/scripts/build-ffmpeg-windows.sh
+++ b/scripts/build-ffmpeg-windows.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -euo pipefail
+export PATH="/mingw64/bin:/usr/bin:${PATH:-}"
+
+PREFIX="$PWD/.build-cache/prefix"
+SRC="$PWD/.build-cache/src"
+mkdir -p "$PREFIX" "$SRC"
+export PKG_CONFIG_PATH="$PREFIX/lib/pkgconfig"
+
+wget -q "https://ffmpeg.org/releases/ffmpeg-${FFMPEG_VERSION}.tar.gz" -O "$SRC/ffmpeg.tar.gz"
+mkdir -p "$SRC/ffmpeg" && tar -C "$SRC/ffmpeg" --strip-components=1 -xzf "$SRC/ffmpeg.tar.gz"
+cd "$SRC/ffmpeg"
+
+./configure \
+  --prefix="$PREFIX" \
+  --pkg-config=pkg-config \
+  --pkg-config-flags="--static" \
+  --target-os=mingw32 \
+  --arch=x86_64 \
+  --enable-gpl --enable-version3 \
+  --enable-libx264 --enable-libx265 --enable-libaom --enable-libvpx --enable-libopus \
+  --disable-doc --disable-debug --enable-stripping --enable-static --disable-shared \
+  --extra-ldflags="-Wl,--start-group" --extra-ldexeflags="-Wl,--end-group" \
+  $( [[ "${ENABLE_NONFREE:-false}" == "true" ]] && echo --enable-nonfree )
+
+make -j$(nproc)
+make install
+
+OUT_DIR="$PWD/../../out/windows-x86_64"
+rm -rf "$OUT_DIR" && mkdir -p "$OUT_DIR/bin"
+cp -av "$PREFIX/bin/ffmpeg.exe" "$OUT_DIR/bin/"
+cp -av "$PREFIX/bin/ffprobe.exe" "$OUT_DIR/bin/" || true

--- a/scripts/build-ffmpeg.ps1
+++ b/scripts/build-ffmpeg.ps1
@@ -2,6 +2,7 @@ Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
 $env:MSYSTEM = "MINGW64"
+$env:CHERE_INVOKING = "1"
 & "C:\msys64\usr\bin\bash.exe" -lc @"
 set -euo pipefail
 PREFIX="`$PWD/.build-cache/prefix"

--- a/scripts/build-ffmpeg.ps1
+++ b/scripts/build-ffmpeg.ps1
@@ -35,9 +35,9 @@ cd \$SRC/ffmpeg
   --enable-gpl --enable-version3 \
   --enable-libx264 --enable-libx265 --enable-libaom --enable-libsvtav1 --enable-libvpx --enable-libopus \
   --disable-doc --disable-debug --enable-stripping --enable-static --disable-shared \
-  \$( [[ "$ENABLE_NONFREE" == "true" || "$ENABLE_NONFREE" == "1" ]] && echo --enable-nonfree )
+  `$( [[ "$ENABLE_NONFREE" == "true" || "$ENABLE_NONFREE" == "1" ]] && echo --enable-nonfree )
 
-make -j\$(nproc)
+make -j`$(nproc)
 make install
 
 OUT_DIR="\$PWD/../../out/windows-x86_64"

--- a/scripts/build-ffmpeg.ps1
+++ b/scripts/build-ffmpeg.ps1
@@ -5,6 +5,7 @@ $env:MSYSTEM = "MINGW64"
 $env:CHERE_INVOKING = "1"
 & "C:\msys64\usr\bin\bash.exe" -lc @"
 set -euo pipefail
+export PATH="/mingw64/bin:/usr/bin:${PATH:-}"
 PREFIX="`$PWD/.build-cache/prefix"
 SRC="`$PWD/.build-cache/src"
 mkdir -p "`$PREFIX" "`$SRC"

--- a/scripts/build-ffmpeg.ps1
+++ b/scripts/build-ffmpeg.ps1
@@ -6,12 +6,12 @@ $FFMPEG_VERSION = if ($env:FFMPEG_VERSION) { $env:FFMPEG_VERSION } else { (yq '.
 $ENABLE_NONFREE = if ($env:ENABLE_NONFREE) { $env:ENABLE_NONFREE } else { (yq '.ffmpeg.nonfree' $PROFILE_FILE) }
 
 # Delegate to MSYS2 environment
-& C:\tools\msys64\usr\bin\bash -lc @"
+& C:\msys64\usr\bin\bash -lc @"
 set -euo pipefail
-PREFIX="\$PWD/.build-cache/prefix"
-SRC="\$PWD/.build-cache/src"
-mkdir -p "\$PREFIX" "\$SRC"
-export PKG_CONFIG_PATH="\$PREFIX/lib/pkgconfig"
+PREFIX="`$PWD/.build-cache/prefix"
+SRC="`$PWD/.build-cache/src"
+mkdir -p "`$PREFIX" "`$SRC"
+export PKG_CONFIG_PATH="`$PREFIX/lib/pkgconfig"
 
 # For Windows, prefer using mingw prebuilt libs to keep CI time reasonable
 # (x264/x265/aom/svt-av1/opus/vpx are available via pacman)
@@ -22,12 +22,12 @@ pacman -Sy --noconfirm --needed \
   mingw-w64-x86_64-opus mingw-w64-x86_64-libvpx
 
 # Rebuild FFmpeg from source to control flags (links to mingw libs)
-wget -q https://github.com/FFmpeg/FFmpeg/archive/refs/tags/n$FFMPEG_VERSION.tar.gz -O \$SRC/ffmpeg.tar.gz
-mkdir -p \$SRC/ffmpeg && tar -C \$SRC/ffmpeg --strip-components=1 -xzf \$SRC/ffmpeg.tar.gz
-cd \$SRC/ffmpeg
+wget -q https://ffmpeg.org/releases/ffmpeg-$FFMPEG_VERSION.tar.gz -O `$SRC/ffmpeg.tar.gz
+mkdir -p `$SRC/ffmpeg && tar -C `$SRC/ffmpeg --strip-components=1 -xzf `$SRC/ffmpeg.tar.gz
+cd `$SRC/ffmpeg
 
 ./configure \
-  --prefix="\$PREFIX" \
+  --prefix="`$PREFIX" \
   --pkg-config=pkg-config \
   --pkg-config-flags="--static" \
   --target-os=mingw32 \
@@ -40,8 +40,8 @@ cd \$SRC/ffmpeg
 make -j`$(nproc)
 make install
 
-OUT_DIR="\$PWD/../../out/windows-x86_64"
-rm -rf "\$OUT_DIR" && mkdir -p "\$OUT_DIR/bin" "\$OUT_DIR/LICENSES"
-cp -av "\$PREFIX/bin/ffmpeg.exe" "\$OUT_DIR/bin/"
-cp -av "\$PREFIX/bin/ffprobe.exe" "\$OUT_DIR/bin/" || true
+OUT_DIR="`$PWD/../../out/windows-x86_64"
+rm -rf "`$OUT_DIR" && mkdir -p "`$OUT_DIR/bin" "`$OUT_DIR/LICENSES"
+cp -av "`$PREFIX/bin/ffmpeg.exe" "`$OUT_DIR/bin/"
+cp -av "`$PREFIX/bin/ffprobe.exe" "`$OUT_DIR/bin/" || true
 "@

--- a/scripts/build-ffmpeg.ps1
+++ b/scripts/build-ffmpeg.ps1
@@ -6,7 +6,7 @@ $FFMPEG_VERSION = if ($env:FFMPEG_VERSION) { $env:FFMPEG_VERSION } else { (yq '.
 $ENABLE_NONFREE = if ($env:ENABLE_NONFREE) { $env:ENABLE_NONFREE } else { (yq '.ffmpeg.nonfree' $PROFILE_FILE) }
 
 # Delegate to MSYS2 environment
-& C:\msys64\usr\bin\bash -lc @"
+& "$env:USERPROFILE\scoop\apps\msys2\current\usr\bin\bash" -lc @"
 set -euo pipefail
 PREFIX="`$PWD/.build-cache/prefix"
 SRC="`$PWD/.build-cache/src"

--- a/scripts/build-ffmpeg.ps1
+++ b/scripts/build-ffmpeg.ps1
@@ -22,6 +22,7 @@ cd `$SRC/ffmpeg
   --enable-gpl --enable-version3 \
   --enable-libx264 --enable-libx265 --enable-libaom --enable-libvpx --enable-libopus \
   --disable-doc --disable-debug --enable-stripping --enable-static --disable-shared \
+  --extra-ldflags="-Wl,--start-group" --extra-ldexeflags="-Wl,--end-group" \
   `$( [[ "$($env:ENABLE_NONFREE)" == "true" ]] && echo --enable-nonfree )
 
 make -j`$(nproc)

--- a/scripts/build-ffmpeg.ps1
+++ b/scripts/build-ffmpeg.ps1
@@ -5,7 +5,8 @@ if (-not $PROFILE_FILE) { $PROFILE_FILE = 'profiles/desktop-default.yml' }
 $FFMPEG_VERSION = if ($env:FFMPEG_VERSION) { $env:FFMPEG_VERSION } else { (yq '.ffmpeg.version' $PROFILE_FILE) }
 $ENABLE_NONFREE = if ($env:ENABLE_NONFREE) { $env:ENABLE_NONFREE } else { (yq '.ffmpeg.nonfree' $PROFILE_FILE) }
 
-# Delegate to MSYS2 environment
+# Delegate to MSYS2 MINGW64 environment
+$env:MSYSTEM = "MINGW64"
 & "$env:USERPROFILE\scoop\apps\msys2\current\usr\bin\bash" -lc @"
 set -euo pipefail
 PREFIX="`$PWD/.build-cache/prefix"

--- a/scripts/build-ffmpeg.ps1
+++ b/scripts/build-ffmpeg.ps1
@@ -1,29 +1,15 @@
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
-$PROFILE_FILE = $env:PROFILE
-if (-not $PROFILE_FILE) { $PROFILE_FILE = 'profiles/desktop-default.yml' }
-$FFMPEG_VERSION = if ($env:FFMPEG_VERSION) { $env:FFMPEG_VERSION } else { (yq '.ffmpeg.version' $PROFILE_FILE) }
-$ENABLE_NONFREE = if ($env:ENABLE_NONFREE) { $env:ENABLE_NONFREE } else { (yq '.ffmpeg.nonfree' $PROFILE_FILE) }
 
-# Delegate to MSYS2 MINGW64 environment
 $env:MSYSTEM = "MINGW64"
-& "$env:USERPROFILE\scoop\apps\msys2\current\usr\bin\bash" -lc @"
+& "C:\msys64\usr\bin\bash.exe" -lc @"
 set -euo pipefail
 PREFIX="`$PWD/.build-cache/prefix"
 SRC="`$PWD/.build-cache/src"
 mkdir -p "`$PREFIX" "`$SRC"
 export PKG_CONFIG_PATH="`$PREFIX/lib/pkgconfig"
 
-# For Windows, prefer using mingw prebuilt libs to keep CI time reasonable
-# (x264/x265/aom/svt-av1/opus/vpx are available via pacman)
-pacman -Sy --noconfirm --needed \
-  mingw-w64-x86_64-ffmpeg \
-  mingw-w64-x86_64-x264 mingw-w64-x86_64-x265 \
-  mingw-w64-x86_64-aom mingw-w64-x86_64-svt-av1 \
-  mingw-w64-x86_64-opus mingw-w64-x86_64-libvpx
-
-# Rebuild FFmpeg from source to control flags (links to mingw libs)
-wget -q https://ffmpeg.org/releases/ffmpeg-$FFMPEG_VERSION.tar.gz -O `$SRC/ffmpeg.tar.gz
+wget -q https://ffmpeg.org/releases/ffmpeg-$($env:FFMPEG_VERSION).tar.gz -O `$SRC/ffmpeg.tar.gz
 mkdir -p `$SRC/ffmpeg && tar -C `$SRC/ffmpeg --strip-components=1 -xzf `$SRC/ffmpeg.tar.gz
 cd `$SRC/ffmpeg
 
@@ -34,15 +20,15 @@ cd `$SRC/ffmpeg
   --target-os=mingw32 \
   --arch=x86_64 \
   --enable-gpl --enable-version3 \
-  --enable-libx264 --enable-libx265 --enable-libaom --enable-libsvtav1 --enable-libvpx --enable-libopus \
+  --enable-libx264 --enable-libx265 --enable-libaom --enable-libvpx --enable-libopus \
   --disable-doc --disable-debug --enable-stripping --enable-static --disable-shared \
-  `$( [[ "$ENABLE_NONFREE" == "true" || "$ENABLE_NONFREE" == "1" ]] && echo --enable-nonfree )
+  `$( [[ "$($env:ENABLE_NONFREE)" == "true" ]] && echo --enable-nonfree )
 
 make -j`$(nproc)
 make install
 
 OUT_DIR="`$PWD/../../out/windows-x86_64"
-rm -rf "`$OUT_DIR" && mkdir -p "`$OUT_DIR/bin" "`$OUT_DIR/LICENSES"
+rm -rf "`$OUT_DIR" && mkdir -p "`$OUT_DIR/bin"
 cp -av "`$PREFIX/bin/ffmpeg.exe" "`$OUT_DIR/bin/"
 cp -av "`$PREFIX/bin/ffprobe.exe" "`$OUT_DIR/bin/" || true
 "@

--- a/scripts/package-windows.sh
+++ b/scripts/package-windows.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+export PATH="/mingw64/bin:/usr/bin:${PATH:-}"
+
+OUT_DIR=".build-cache/out/windows-x86_64"
+
+if [[ ! -x "$OUT_DIR/bin/ffmpeg.exe" ]]; then
+  echo "[error] No ffmpeg.exe found in $OUT_DIR/bin"
+  exit 1
+fi
+
+ver=$("$OUT_DIR/bin/ffmpeg.exe" -version 2>&1 | awk 'NR==1{print $3}')
+
+# Copy required MinGW runtime DLLs (skip Windows system DLLs)
+for bin in "$OUT_DIR/bin/"*.exe; do
+  ldd "$bin" | awk '{print $3}' | grep -i '/mingw64/bin/' | while read dll; do
+    [[ -f "$dll" ]] && cp -n "$dll" "$OUT_DIR/bin/" && echo "Copied: $(basename "$dll")"
+  done
+done
+
+NONFREE_SUFFIX=""
+[[ "${ENABLE_NONFREE:-false}" == "true" ]] && NONFREE_SUFFIX="-nonfree"
+
+mkdir -p dist
+zip_path="dist/ffmpeg-${ver}-windows-x86_64${NONFREE_SUFFIX}.zip"
+(cd .build-cache/out && zip -r "../../$zip_path" windows-x86_64)
+
+echo "==> Package written: $zip_path"

--- a/scripts/package-windows.sh
+++ b/scripts/package-windows.sh
@@ -13,7 +13,9 @@ ver=$("$OUT_DIR/bin/ffmpeg.exe" -version 2>&1 | awk 'NR==1{print $3}')
 
 # Copy required MinGW runtime DLLs (skip Windows system DLLs)
 for bin in "$OUT_DIR/bin/"*.exe; do
-  ldd "$bin" | awk '{print $3}' | grep -i '/mingw64/bin/' | while read dll; do
+  dlls=$(ldd "$bin" | awk '{print $3}' | grep -i '/mingw64/bin/' || true)
+  [[ -z "$dlls" ]] && continue
+  echo "$dlls" | while read dll; do
     [[ -f "$dll" ]] && cp -n "$dll" "$OUT_DIR/bin/" && echo "Copied: $(basename "$dll")"
   done
 done

--- a/scripts/package.ps1
+++ b/scripts/package.ps1
@@ -4,44 +4,42 @@ $ErrorActionPreference = 'Stop'
 $env:MSYSTEM = "MINGW64"
 $env:CHERE_INVOKING = "1"
 
-$enableNonfree = $env:ENABLE_NONFREE
+$outDir = ".build-cache\out\windows-x86_64"
+$ffmpeg = "$outDir\bin\ffmpeg.exe"
 
+if (-not (Test-Path $ffmpeg)) {
+  throw "[error] No ffmpeg.exe found in $outDir\bin"
+}
+
+# Get version
+$ver = (& $ffmpeg -version 2>&1)[0] -replace '^ffmpeg version (\S+).*', '$1'
+
+# Find required MinGW DLLs via ldd, skip Windows system DLLs
 $script = @'
-set -euo pipefail
-
-OUT_DIR=".build-cache/out/windows-x86_64"
-
-if [[ ! -x "$OUT_DIR/bin/ffmpeg.exe" ]]; then
-  echo "[error] No ffmpeg.exe found in $OUT_DIR/bin"
-  exit 1
-fi
-
-# Get version from binary
-ver=$("$OUT_DIR/bin/ffmpeg.exe" -version 2>&1 | awk 'NR==1{print $3}')
-
-# Copy required MinGW runtime DLLs (skip Windows system DLLs)
-for bin in "$OUT_DIR/bin/"*.exe; do
-  ldd "$bin" | awk '{print $3}' | grep -v '^/c/Windows' | grep -v 'not found' | grep -v '^$' | while read dll; do
-    [[ -f "$dll" ]] && cp -n "$dll" "$OUT_DIR/bin/" && echo "Copied: $dll"
-  done
+for bin in .build-cache/out/windows-x86_64/bin/*.exe; do
+  ldd "$bin" | awk '{print $3}' | grep -iv '^/c/windows' | grep -v 'not found' | grep -v '^$'
 done
-
-NONFREE_SUFFIX=""
-[[ "ENABLE_NONFREE_PLACEHOLDER" == "true" ]] && NONFREE_SUFFIX="-nonfree"
-
-mkdir -p dist
-zip_path="dist/ffmpeg-${ver}-windows-x86_64${NONFREE_SUFFIX}.zip"
-(cd .build-cache/out && zip -r "../../$zip_path" windows-x86_64)
-
-echo "==> Package written: $zip_path"
 '@
-
-$script = $script -replace 'ENABLE_NONFREE_PLACEHOLDER', $enableNonfree
-
 $tmpScript = [System.IO.Path]::GetTempFileName() + ".sh"
-$script | Set-Content -Path $tmpScript -Encoding UTF8 -NoNewline
+[System.IO.File]::WriteAllText($tmpScript, $script, [System.Text.Encoding]::ASCII)
 $tmpScriptMsys = & "C:\msys64\usr\bin\cygpath.exe" $tmpScript
 
-& "C:\msys64\usr\bin\bash.exe" -lc "bash '$tmpScriptMsys'"
-
+$dlls = & "C:\msys64\usr\bin\bash.exe" -lc "bash '$tmpScriptMsys'" | Sort-Object -Unique
 Remove-Item $tmpScript
+
+foreach ($dll in $dlls) {
+  $dllWin = & "C:\msys64\usr\bin\cygpath.exe" -w $dll
+  $dest = "$outDir\bin\$(Split-Path $dllWin -Leaf)"
+  if (-not (Test-Path $dest)) {
+    Copy-Item $dllWin $dest
+    Write-Host "Copied: $(Split-Path $dllWin -Leaf)"
+  }
+}
+
+# Package
+$nonfree = if ($env:ENABLE_NONFREE -eq "true") { "-nonfree" } else { "" }
+New-Item -ItemType Directory -Force -Path "dist" | Out-Null
+$zipPath = "dist\ffmpeg-$ver-windows-x86_64$nonfree.zip"
+Compress-Archive -Path "$outDir\*" -DestinationPath $zipPath -Force
+
+Write-Host "==> Package written: $zipPath"

--- a/scripts/package.ps1
+++ b/scripts/package.ps1
@@ -1,0 +1,34 @@
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$env:MSYSTEM = "MINGW64"
+$env:CHERE_INVOKING = "1"
+& "C:\msys64\usr\bin\bash.exe" -lc @"
+set -euo pipefail
+
+OUT_DIR=".build-cache/out/windows-x86_64"
+
+if [[ ! -x "`$OUT_DIR/bin/ffmpeg.exe" ]]; then
+  echo "[error] No ffmpeg.exe found in `$OUT_DIR/bin"
+  exit 1
+fi
+
+# Get version from binary
+ver=`$("$OUT_DIR/bin/ffmpeg.exe" -version 2>&1 | awk 'NR==1{print `$3}')
+
+# Copy required MinGW runtime DLLs (skip Windows system DLLs)
+for bin in `$OUT_DIR/bin/*.exe; do
+  ldd "`$bin" | awk '{print `$3}' | grep -v '^/c/Windows' | grep -v 'not found' | grep -v '^`$' | while read dll; do
+    [[ -f "`$dll" ]] && cp -n "`$dll" "`$OUT_DIR/bin/" && echo "Copied: `$dll"
+  done
+done
+
+NONFREE_SUFFIX=""
+[[ "$($env:ENABLE_NONFREE)" == "true" ]] && NONFREE_SUFFIX="-nonfree"
+
+mkdir -p dist
+zip_path="dist/ffmpeg-`${ver}-windows-x86_64`${NONFREE_SUFFIX}.zip"
+(cd .build-cache/out && zip -r "../../`$zip_path" windows-x86_64)
+
+echo "==> Package written: `$zip_path"
+"@

--- a/scripts/package.ps1
+++ b/scripts/package.ps1
@@ -3,32 +3,45 @@ $ErrorActionPreference = 'Stop'
 
 $env:MSYSTEM = "MINGW64"
 $env:CHERE_INVOKING = "1"
-& "C:\msys64\usr\bin\bash.exe" -lc @"
+
+$enableNonfree = $env:ENABLE_NONFREE
+
+$script = @'
 set -euo pipefail
 
 OUT_DIR=".build-cache/out/windows-x86_64"
 
-if [[ ! -x "`$OUT_DIR/bin/ffmpeg.exe" ]]; then
-  echo "[error] No ffmpeg.exe found in `$OUT_DIR/bin"
+if [[ ! -x "$OUT_DIR/bin/ffmpeg.exe" ]]; then
+  echo "[error] No ffmpeg.exe found in $OUT_DIR/bin"
   exit 1
 fi
 
 # Get version from binary
-ver=`$("`$OUT_DIR/bin/ffmpeg.exe" -version 2>&1 | awk 'NR==1{print `$3}')
+ver=$("$OUT_DIR/bin/ffmpeg.exe" -version 2>&1 | awk 'NR==1{print $3}')
 
 # Copy required MinGW runtime DLLs (skip Windows system DLLs)
-for bin in `$OUT_DIR/bin/*.exe; do
-  ldd "`$bin" | awk '{print `$3}' | grep -v '^/c/Windows' | grep -v 'not found' | grep -v '^`$' | while read dll; do
-    [[ -f "`$dll" ]] && cp -n "`$dll" "`$OUT_DIR/bin/" && echo "Copied: `$dll"
+for bin in "$OUT_DIR/bin/"*.exe; do
+  ldd "$bin" | awk '{print $3}' | grep -v '^/c/Windows' | grep -v 'not found' | grep -v '^$' | while read dll; do
+    [[ -f "$dll" ]] && cp -n "$dll" "$OUT_DIR/bin/" && echo "Copied: $dll"
   done
 done
 
 NONFREE_SUFFIX=""
-[[ "$($env:ENABLE_NONFREE)" == "true" ]] && NONFREE_SUFFIX="-nonfree"
+[[ "ENABLE_NONFREE_PLACEHOLDER" == "true" ]] && NONFREE_SUFFIX="-nonfree"
 
 mkdir -p dist
-zip_path="dist/ffmpeg-`${ver}-windows-x86_64`${NONFREE_SUFFIX}.zip"
-(cd .build-cache/out && zip -r "../../`$zip_path" windows-x86_64)
+zip_path="dist/ffmpeg-${ver}-windows-x86_64${NONFREE_SUFFIX}.zip"
+(cd .build-cache/out && zip -r "../../$zip_path" windows-x86_64)
 
-echo "==> Package written: `$zip_path"
-"@
+echo "==> Package written: $zip_path"
+'@
+
+$script = $script -replace 'ENABLE_NONFREE_PLACEHOLDER', $enableNonfree
+
+$tmpScript = [System.IO.Path]::GetTempFileName() + ".sh"
+$script | Set-Content -Path $tmpScript -Encoding UTF8 -NoNewline
+$tmpScriptMsys = & "C:\msys64\usr\bin\cygpath.exe" $tmpScript
+
+& "C:\msys64\usr\bin\bash.exe" -lc "bash '$tmpScriptMsys'"
+
+Remove-Item $tmpScript

--- a/scripts/package.ps1
+++ b/scripts/package.ps1
@@ -14,7 +14,7 @@ if [[ ! -x "`$OUT_DIR/bin/ffmpeg.exe" ]]; then
 fi
 
 # Get version from binary
-ver=`$("$OUT_DIR/bin/ffmpeg.exe" -version 2>&1 | awk 'NR==1{print `$3}')
+ver=`$("`$OUT_DIR/bin/ffmpeg.exe" -version 2>&1 | awk 'NR==1{print `$3}')
 
 # Copy required MinGW runtime DLLs (skip Windows system DLLs)
 for bin in `$OUT_DIR/bin/*.exe; do

--- a/scripts/package.ps1
+++ b/scripts/package.ps1
@@ -11,8 +11,12 @@ if (-not (Test-Path $ffmpeg)) {
   throw "[error] No ffmpeg.exe found in $outDir\bin"
 }
 
-# Get version
-$ver = (& $ffmpeg -version 2>&1)[0] -replace '^ffmpeg version (\S+).*', '$1'
+# Get version from env or binary (via bash where DLLs are available)
+$ver = if ($env:FFMPEG_VERSION) {
+  $env:FFMPEG_VERSION
+} else {
+  (& "C:\msys64\usr\bin\bash.exe" -lc "$($ffmpeg -replace '\\', '/') -version 2>&1" | Select-String 'ffmpeg version').ToString() -replace '^.*ffmpeg version (\S+).*', '$1'
+}
 
 # Find required MinGW DLLs via ldd, skip Windows system DLLs
 $script = @'

--- a/scripts/package.ps1
+++ b/scripts/package.ps1
@@ -17,7 +17,7 @@ $ver = (& $ffmpeg -version 2>&1)[0] -replace '^ffmpeg version (\S+).*', '$1'
 # Find required MinGW DLLs via ldd, skip Windows system DLLs
 $script = @'
 for bin in .build-cache/out/windows-x86_64/bin/*.exe; do
-  ldd "$bin" | awk '{print $3}' | grep -iv '^/c/windows' | grep -v 'not found' | grep -v '^$'
+  ldd "$bin" | awk '{print $3}' | grep -i '/mingw64/bin/'
 done
 '@
 $tmpScript = [System.IO.Path]::GetTempFileName() + ".sh"


### PR DESCRIPTION
## Summary
- Adds Windows x86_64 build and packaging scripts
- Bootstrap, build, and package scripts for Windows CI runner
- Tested via workflow_dispatch — latest runs succeed for both macOS arm64 and Windows x86_64

## Test plan
- [x] `feat/windows-build` CI passes for `windows-2022 • x86_64`
- [x] `feat/windows-build` CI passes for `macos-26 • arm64`
- [ ] Tag push will build all platforms and publish release assets

🤖 Generated with [Claude Code](https://claude.com/claude-code)